### PR TITLE
Fix connection greeting broadcast

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -61,7 +61,7 @@ function broadcast(message: string): void {
 server.on('connection', (ws: WebSocket) => {
     clients.add(ws);
     console.log('New client connected');
-    broadcast('🤖 AI: Welcome to Snake Game! Feel free to ask for help or tips!');
+    ws.send('🤖 AI: Welcome to Snake Game! Feel free to ask for help or tips!');
 
     ws.on('message', (message: WebSocket.RawData) => {
         const messageStr = message.toString();


### PR DESCRIPTION
## Summary
- greet the connecting client directly instead of broadcasting to all clients

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68471b15f77c8320b295f366c86de67b