### PR TITLE
Use wss for external hosts and change WebSocket port

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -42,7 +42,7 @@ For example, when we faced a WebSocket connection issue:
 
 ```bash
 Error: WebSocket connection failed
-At: ws://localhost:12345
+At: ws://localhost:49123
 Reason: ECONNREFUSED
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN npm install
 RUN npm install typescript -g
 RUN tsc
 
-EXPOSE 12345
+EXPOSE 49123
 
 CMD ["node", "dist/server.js"]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Curious about how an AI creates a game? Check out our [detailed blog post](BLOG.
    ```
    This will:
    - Build the TypeScript code
-   - Start the WebSocket server on port 12345
+   - Start the WebSocket server on port 49123
    - Start the static file server on port 8080
 
 4. Open your browser and navigate to:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   backend:
     build: .
     ports:
-      - "12345:12345"
+      - "49123:49123"
     volumes:
       - ./src:/app/src
 

--- a/public/game.js
+++ b/public/game.js
@@ -92,7 +92,8 @@ class Game {
 
         // Initialize WebSocket connection
         const host = window.location.hostname;
-        this.ws = new WebSocket(`ws://${host}:12345`);
+        const protocol = (host === 'localhost' || host === '127.0.0.1' || host === '::1') ? 'ws' : 'wss';
+        this.ws = new WebSocket(`${protocol}://${host}:49123`);
         
         // Handle incoming messages from WebSocket
         this.ws.onmessage = (event) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,7 @@ interface AIResponses {
     [key: string]: AICategory;
 }
 
-const PORT = 12345;
+const PORT = 49123;
 const server = new WebSocket.Server({ port: PORT });
 const clients: Set<WebSocket> = new Set();
 


### PR DESCRIPTION
## Summary
- change WebSocket port from `12345` to `49123`
- use secure WebSocket for non-localhost clients
- update docs and Docker configuration

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6847dcf5808083209094f23eb6198ea9