### PR TITLE
Implement berry leaderboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -145,6 +145,14 @@
         .chat-send:hover {
             background-color: #45a049;
         }
+        .leaderboard-container {
+            margin-top: 20px;
+            width: 100%;
+            max-width: 400px;
+        }
+        #leaderboard {
+            padding-left: 20px;
+        }
     </style>
 </head>
 <body>
@@ -178,6 +186,10 @@
                 <span class="slider"></span>
             </label>
         </div>
+    </div>
+    <div id="leaderboardContainer" class="leaderboard-container">
+        <h3>Berry Mode Leaderboard</h3>
+        <ol id="leaderboard"></ol>
     </div>
     <script src="game.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- implement server-side leaderboard tracking for berry mode
- broadcast leaderboard updates via websocket
- update frontend to display leaderboard and send score submissions
- show scoreboard submission prompt when eligible

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d07efe2d0832088327507c3b8ae4a