### PR TITLE
Fix leaderboard initial render and numbering

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -93,6 +93,7 @@ class Game {
         this.chatMessages = document.getElementById('chatMessages');
         this.leaderboardElement = document.getElementById('leaderboard');
         this.leaderboard = [];
+        this.renderLeaderboard();
 
         // Vibe mode toggle
         this.autopilot = false;
@@ -404,8 +405,7 @@ class Game {
     renderLeaderboard() {
         if (!this.leaderboardElement) return;
         this.leaderboardElement.innerHTML = this.leaderboard
-            .map((e, i) => `${i + 1}. ${e.name} - ${e.score}`)
-            .map(text => `<li>${text}</li>`)
+            .map(e => `<li>${e.name} - ${e.score}</li>`)
             .join('');
     }
 


### PR DESCRIPTION
## Summary
- render leaderboard on page load
- avoid duplicate numbering by relying on `<ol>` numbering

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dd9bfa1348320b699e2932f1261c4