### PR TITLE
Implement multiplayer names and online player list

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -96,6 +96,8 @@ class Game {
         this.remoteSnake = null;
         this.remotePlayers = [];
         this.playerId = null;
+        this.onlinePlayersList = document.getElementById('onlinePlayersList');
+        this.onlinePlayersContainer = document.getElementById('onlinePlayersContainer');
         this.renderLeaderboard();
 
         // Vibe mode toggle
@@ -163,6 +165,7 @@ class Game {
                 if (data.type === 'multiplayer-state') {
                     this.remoteSnake = data.snake;
                     this.remotePlayers = data.players;
+                    this.renderOnlinePlayers();
                     return;
                 }
             } catch (e) {
@@ -483,8 +486,16 @@ class Game {
             .join('');
     }
 
+    renderOnlinePlayers() {
+        if (!this.onlinePlayersList) return;
+        this.onlinePlayersList.innerHTML = this.remotePlayers
+            .map(p => `<li>${p.emoji} ${p.name || ''}</li>`)
+            .join('');
+    }
+
     enterMultiplayer() {
         document.getElementById('leaderboardContainer').style.display = 'none';
+        this.onlinePlayersContainer.style.display = 'block';
         this.vibeToggle.disabled = true;
         this.berryToggle.disabled = true;
         this.vibeToggle.checked = false;
@@ -494,12 +505,20 @@ class Game {
         this.snake.reset();
         this.food.move();
         if (this.ws.readyState === WebSocket.OPEN) {
-            this.ws.send(JSON.stringify({ type: 'join-multiplayer' }));
+            const name = prompt('Enter your name:');
+            if (name) {
+                this.ws.send(JSON.stringify({ type: 'join-multiplayer', name }));
+            } else {
+                this.multiToggle.checked = false;
+                this.onlinePlayersContainer.style.display = 'none';
+                return;
+            }
         }
     }
 
     exitMultiplayer() {
         document.getElementById('leaderboardContainer').style.display = '';
+        this.onlinePlayersContainer.style.display = 'none';
         this.vibeToggle.disabled = false;
         this.berryToggle.disabled = false;
         this.multiToggle.checked = false;
@@ -512,6 +531,7 @@ class Game {
         }
         this.remoteSnake = null;
         this.remotePlayers = [];
+        this.renderOnlinePlayers();
         this.playerId = null;
         this.reset();
     }

--- a/public/index.html
+++ b/public/index.html
@@ -150,6 +150,11 @@
             width: 100%;
             max-width: 400px;
         }
+        .online-players {
+            margin-top: 20px;
+            width: 100%;
+            max-width: 400px;
+        }
         #leaderboard {
             padding-left: 20px;
         }
@@ -168,6 +173,10 @@
                 <button class="chat-send" id="chatSend">Send</button>
             </div>
         </div>
+    </div>
+    <div id="onlinePlayersContainer" class="online-players" style="display:none;">
+        <h3>Players Online</h3>
+        <ul id="onlinePlayersList"></ul>
     </div>
     <div class="controls">
         <p>Use arrow keys or swipe to control the snake</p>

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,7 @@ interface MultiplayerPlayer {
     x: number;
     y: number;
     emoji: string;
+    name: string;
 }
 
 interface SnakeState {
@@ -68,6 +69,7 @@ function broadcastMultiplayerState(): void {
             x: p.x,
             y: p.y,
             emoji: p.emoji,
+            name: p.name,
         })),
     };
     broadcast(JSON.stringify(state));
@@ -202,7 +204,7 @@ server.on('connection', (ws: WebSocket) => {
                 sendLeaderboard();
                 return;
             }
-            if (data.type === 'join-multiplayer') {
+            if (data.type === 'join-multiplayer' && typeof data.name === 'string') {
                 if (!multiplayerPlayers.has(ws)) {
                     const id = Math.random().toString(36).slice(2, 8);
                     const emoji = emojis[Math.floor(Math.random() * emojis.length)];
@@ -212,9 +214,10 @@ server.on('connection', (ws: WebSocket) => {
                         x: Math.floor(Math.random() * 20) * 20,
                         y: Math.floor(Math.random() * 20) * 20,
                         emoji,
+                        name: data.name,
                     };
                     multiplayerPlayers.set(ws, player);
-                    ws.send(JSON.stringify({ type: 'init-multiplayer', id, emoji }));
+                    ws.send(JSON.stringify({ type: 'init-multiplayer', id, emoji, name: data.name }));
                     broadcastMultiplayerState();
                 }
                 return;


### PR DESCRIPTION
## Summary
- ask for name before joining multiplayer
- track player names on server and broadcast them
- show list of online players under the game field

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f1c7fa5808320add2b82bfc988d4e