### PR TITLE
Fix multiplayer AI and scoring

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -165,6 +165,10 @@ class Game {
                 if (data.type === 'multiplayer-state') {
                     this.remoteSnake = data.snake;
                     this.remotePlayers = data.players;
+                    if (typeof data.score === 'number') {
+                        this.score = data.score;
+                        document.getElementById('score').textContent = this.score;
+                    }
                     this.renderOnlinePlayers();
                     return;
                 }
@@ -239,7 +243,9 @@ class Game {
             }
             this.remotePlayers.forEach(p => {
                 this.ctx.font = '20px Arial';
-                this.ctx.fillText(p.emoji, p.x + 2, p.y + 18);
+                this.ctx.textAlign = 'center';
+                this.ctx.textBaseline = 'middle';
+                this.ctx.fillText(p.emoji, p.x + 10, p.y + 10);
             });
             this.lastUpdateTime = timestamp;
             requestAnimationFrame(this.gameLoop);


### PR DESCRIPTION
## Summary
- improve server snake logic with BFS pathfinding to nearest player
- track multiplayer score on the server and broadcast to clients
- center fruit emojis and update score in multiplayer mode

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f233e159c832083912c68f22e9378