### PR TITLE
Implement persistent player IDs in multiplayer leaderboard

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -93,12 +93,15 @@ class Game {
         this.chatMessages = document.getElementById('chatMessages');
         this.leaderboardElement = document.getElementById('leaderboard');
         this.leaderboard = [];
+        this.mpLeaderboardElement = document.getElementById('mpLeaderboard');
+        this.mpLeaderboard = [];
         this.remoteSnake = null;
         this.remotePlayers = [];
         this.playerId = null;
         this.onlinePlayersList = document.getElementById('onlinePlayersList');
         this.onlinePlayersContainer = document.getElementById('onlinePlayersContainer');
         this.renderLeaderboard();
+        this.renderMpLeaderboard();
 
         // Vibe mode toggle
         this.autopilot = false;
@@ -164,6 +167,11 @@ class Game {
                 if (data.type === 'leaderboard') {
                     this.leaderboard = data.leaderboard;
                     this.renderLeaderboard();
+                    return;
+                }
+                if (data.type === 'mp-leaderboard') {
+                    this.mpLeaderboard = data.leaderboard;
+                    this.renderMpLeaderboard();
                     return;
                 }
                 if (data.type === 'init-multiplayer') {
@@ -525,6 +533,13 @@ class Game {
             .join('');
     }
 
+    renderMpLeaderboard() {
+        if (!this.mpLeaderboardElement) return;
+        this.mpLeaderboardElement.innerHTML = this.mpLeaderboard
+            .map(e => `<li>${e.names} - ${e.score}</li>`)
+            .join('');
+    }
+
     renderOnlinePlayers() {
         if (!this.onlinePlayersList) return;
         this.onlinePlayersList.innerHTML = this.remotePlayers
@@ -534,6 +549,7 @@ class Game {
 
     enterMultiplayer() {
         document.getElementById('leaderboardContainer').style.display = 'none';
+        document.getElementById('mpLeaderboardContainer').style.display = 'block';
         this.onlinePlayersContainer.style.display = 'block';
         this.vibeToggle.disabled = true;
         this.berryToggle.disabled = true;
@@ -562,6 +578,7 @@ class Game {
 
     exitMultiplayer() {
         document.getElementById('leaderboardContainer').style.display = '';
+        document.getElementById('mpLeaderboardContainer').style.display = 'none';
         this.onlinePlayersContainer.style.display = 'none';
         this.vibeToggle.disabled = false;
         this.berryToggle.disabled = false;

--- a/public/index.html
+++ b/public/index.html
@@ -207,6 +207,10 @@
         <h3>Berry Mode Leaderboard</h3>
         <ol id="leaderboard"></ol>
     </div>
+    <div id="mpLeaderboardContainer" class="leaderboard-container" style="display:none;">
+        <h3>Multiplayer Leaderboard</h3>
+        <ol id="mpLeaderboard"></ol>
+    </div>
     <script src="game.js"></script>
 </body>
 </html>

--- a/src/db.ts
+++ b/src/db.ts
@@ -4,6 +4,7 @@ import sqlite3 from 'sqlite3';
 import { open, Database } from 'sqlite';
 
 export interface User {
+    id: string;
     token: string;
     name: string;
     emoji: string | null;
@@ -25,35 +26,71 @@ export async function initDB(): Promise<void> {
 async function createSchema(): Promise<void> {
     await db.exec(`CREATE TABLE IF NOT EXISTS users (
         token TEXT PRIMARY KEY,
+        id TEXT,
         name TEXT,
         emoji TEXT
+    )`);
+    await db.exec(`CREATE TABLE IF NOT EXISTS mp_leaderboard (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        ids TEXT,
+        names TEXT,
+        score INTEGER,
+        date INTEGER
     )`);
 }
 
 async function verifySchema(): Promise<void> {
     try {
-        await db.get(`SELECT token, name, emoji FROM users LIMIT 1`);
+        await db.get(`SELECT token, id, name, emoji FROM users LIMIT 1`);
     } catch {
-        // try adding emoji column if it doesn't exist
+        try {
+            await db.exec(`ALTER TABLE users ADD COLUMN id TEXT`);
+        } catch {}
         try {
             await db.exec(`ALTER TABLE users ADD COLUMN emoji TEXT`);
+        } catch {}
+        // if table still invalid create from scratch
+        try {
+            await db.get(`SELECT token, id, name, emoji FROM users LIMIT 1`);
         } catch {
-            // table might not exist
             await createSchema();
         }
     }
+
+    // ensure mp_leaderboard table exists
+    try {
+        await db.get(`SELECT ids, names, score, date FROM mp_leaderboard LIMIT 1`);
+    } catch {
+        await db.exec(`CREATE TABLE IF NOT EXISTS mp_leaderboard (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ids TEXT,
+            names TEXT,
+            score INTEGER,
+            date INTEGER
+        )`);
+    }
 }
 
-export async function createUser(name: string, token: string, emoji: string): Promise<void> {
-    await db.run(`INSERT INTO users (token, name, emoji) VALUES (?, ?, ?)`, token, name, emoji);
+export async function createUser(id: string, name: string, token: string, emoji: string): Promise<void> {
+    await db.run(
+        `INSERT INTO users (token, id, name, emoji) VALUES (?, ?, ?, ?)`,
+        token,
+        id,
+        name,
+        emoji,
+    );
 }
 
 export async function getUserByToken(token: string): Promise<User | undefined> {
-    return db.get<User>(`SELECT token, name, emoji FROM users WHERE token = ?`, token);
+    return db.get<User>(`SELECT token, id, name, emoji FROM users WHERE token = ?`, token);
 }
 
 export async function updateUserEmoji(token: string, emoji: string): Promise<void> {
     await db.run(`UPDATE users SET emoji = ? WHERE token = ?`, emoji, token);
+}
+
+export async function updateUserId(token: string, id: string): Promise<void> {
+    await db.run(`UPDATE users SET id = ? WHERE token = ?`, id, token);
 }
 
 export async function getLeastUsedEmoji(emojis: string[]): Promise<string> {
@@ -73,4 +110,29 @@ export async function getLeastUsedEmoji(emojis: string[]): Promise<string> {
         }
     }
     return selected;
+}
+
+export interface MultiplayerEntry {
+    ids: string;
+    names: string;
+    score: number;
+    date: number;
+}
+
+export async function addMultiplayerScore(ids: string, names: string, score: number): Promise<void> {
+    const date = Date.now();
+    await db.run(
+        `INSERT INTO mp_leaderboard (ids, names, score, date) VALUES (?, ?, ?, ?)`,
+        ids,
+        names,
+        score,
+        date,
+    );
+}
+
+export async function getMultiplayerLeaderboard(limit = 20): Promise<MultiplayerEntry[]> {
+    return db.all<MultiplayerEntry[]>(
+        `SELECT ids, names, score, date FROM mp_leaderboard ORDER BY score ASC, id ASC LIMIT ?`,
+        limit,
+    );
 }


### PR DESCRIPTION
## Summary
- add `id` column for users and store session UUIDs
- track player IDs and timestamp (ms) in multiplayer leaderboard
- update server logic to persist ID and save names & IDs

## Testing
- `npm run build`
- `node dist/server.js` (server started)


------
https://chatgpt.com/codex/tasks/task_e_68583494c8f48320a9f848d1f7b51f37