### PR TITLE
Add Telegram Mini App auth

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -563,6 +563,8 @@ class Game {
             const stored = localStorage.getItem('playerToken');
             if (stored) {
                 this.ws.send(JSON.stringify({ type: 'join-multiplayer', token: stored }));
+            } else if (window.Telegram && window.Telegram.WebApp && Telegram.WebApp.initData) {
+                this.ws.send(JSON.stringify({ type: 'join-multiplayer', tgInitData: Telegram.WebApp.initData }));
             } else {
                 const name = prompt('Enter your name:');
                 if (name) {

--- a/public/index.html
+++ b/public/index.html
@@ -211,6 +211,7 @@
         <h3>Multiplayer Leaderboard</h3>
         <ol id="mpLeaderboard"></ol>
     </div>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <script src="game.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add telegram_id and nickname fields in DB
- verify Telegram WebApp init data on the server
- handle Telegram Mini App auth when joining multiplayer
- load Telegram WebApp script in HTML
- detect Telegram environment on client

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a28c1b1208320bbce4a86a6438a38