### PR TITLE
Improve auth fallback & add debug logs

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -217,6 +217,13 @@ class Game {
                     this.creditMessage.textContent = `Please wait ${data.wait} min or buy more games.`;
                     return;
                 }
+                if (data.type === 'error') {
+                    console.error('Server error:', data.message);
+                    if (data.message === 'invalid auth') {
+                        localStorage.removeItem('playerToken');
+                    }
+                    return;
+                }
             } catch (e) {
                 // not JSON
             }
@@ -587,21 +594,27 @@ class Game {
         this.snake.reset();
         this.food.move();
         if (this.ws.readyState === WebSocket.OPEN) {
+            const payload = { type: 'join-multiplayer' };
             const stored = localStorage.getItem('playerToken');
+            const hasTg = window.Telegram && window.Telegram.WebApp && Telegram.WebApp.initData;
             if (stored) {
-                this.ws.send(JSON.stringify({ type: 'join-multiplayer', token: stored }));
-            } else if (window.Telegram && window.Telegram.WebApp && Telegram.WebApp.initData) {
-                this.ws.send(JSON.stringify({ type: 'join-multiplayer', tgInitData: Telegram.WebApp.initData }));
-            } else {
+                payload.token = stored;
+            }
+            if (hasTg) {
+                payload.tgInitData = Telegram.WebApp.initData;
+            }
+            if (!stored && !hasTg) {
                 const name = prompt('Enter your name:');
                 if (name) {
-                    this.ws.send(JSON.stringify({ type: 'join-multiplayer', name }));
+                    payload.name = name;
                 } else {
                     this.multiToggle.checked = false;
                     this.onlinePlayersContainer.style.display = 'none';
                     return;
                 }
             }
+            console.log('Sending join request', payload);
+            this.ws.send(JSON.stringify(payload));
         }
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,7 +40,10 @@ interface TelegramAuthResult {
 }
 
 function verifyTelegramInitData(initData: string): TelegramAuthResult | null {
-    if (!BOT_TOKEN) return null;
+    if (!BOT_TOKEN) {
+        console.warn('BOT_TOKEN not set, cannot verify Telegram data');
+        return null;
+    }
     try {
         const params = new URLSearchParams(initData);
         const hash = params.get('hash');
@@ -61,7 +64,10 @@ function verifyTelegramInitData(initData: string): TelegramAuthResult | null {
             .createHmac('sha256', secret)
             .update(dataCheckString)
             .digest('hex');
-        if (hmac !== hash) return null;
+        if (hmac !== hash) {
+            console.warn('Telegram auth hash mismatch');
+            return null;
+        }
         const userStr = params.get('user');
         if (!userStr) return null;
         const user = JSON.parse(userStr);
@@ -71,7 +77,8 @@ function verifyTelegramInitData(initData: string): TelegramAuthResult | null {
         const nickname = user.username || null;
         const telegram_id = String(user.id);
         return { telegram_id, display_name, nickname };
-    } catch {
+    } catch (err) {
+        console.warn('Failed to parse Telegram init data', err);
         return null;
     }
 }
@@ -419,6 +426,11 @@ server.on('connection', (ws: WebSocket) => {
             }
             if (data.type === 'join-multiplayer') {
                 (async () => {
+                    console.log('Join request', {
+                        hasToken: typeof data.token === 'string',
+                        hasTg: typeof data.tgInitData === 'string',
+                        hasName: typeof data.name === 'string',
+                    });
                     if (multiplayerPlayers.has(ws)) return;
                     let name: string | undefined;
                     let token: string | undefined = typeof data.token === 'string' ? data.token : undefined;
@@ -436,6 +448,8 @@ server.on('connection', (ws: WebSocket) => {
                             telegramId = user.telegram_id;
                             gameCredits = user.game_credits;
                             cooldownUntil = user.cooldown_until;
+                        } else {
+                            console.log('Token not found:', token);
                         }
                     }
                     if (!name && typeof data.tgInitData === 'string') {
@@ -459,7 +473,10 @@ server.on('connection', (ws: WebSocket) => {
                                 telegramId = auth.telegram_id;
                                 gameCredits = 0;
                                 cooldownUntil = 0;
+                                console.log('Created new user from Telegram', name);
                             }
+                        } else {
+                            console.log('Failed to verify tgInitData');
                         }
                     }
                     if (!name && typeof data.name === 'string') {
@@ -471,8 +488,10 @@ server.on('connection', (ws: WebSocket) => {
                         telegramId = null;
                         gameCredits = 0;
                         cooldownUntil = 0;
+                        console.log('Created new user from name', name);
                     }
                     if (!name || !token || !id) {
+                        console.warn('Join failed, missing fields', { name, token, id });
                         ws.send(JSON.stringify({ type: 'error', message: 'invalid auth' }));
                         return;
                     }
@@ -504,6 +523,7 @@ server.on('connection', (ws: WebSocket) => {
                         cooldownUntil,
                     };
                     multiplayerPlayers.set(ws, player);
+                    console.log('Player joined', { name, id, telegramId });
                     ws.send(JSON.stringify({ type: 'init-multiplayer', id, emoji, name, token, credits: gameCredits }));
                     sendGameInfo(player);
                     broadcastMultiplayerState();
@@ -534,6 +554,10 @@ server.on('connection', (ws: WebSocket) => {
                 return;
             }
             if (data.type === 'leave-multiplayer') {
+                const player = multiplayerPlayers.get(ws);
+                if (player) {
+                    console.log('Player left', { name: player.name, id: player.id });
+                }
                 multiplayerPlayers.delete(ws);
                 broadcastMultiplayerState();
                 return;
@@ -574,8 +598,13 @@ server.on('connection', (ws: WebSocket) => {
 
     ws.on('close', () => {
         clients.delete(ws);
+        const player = multiplayerPlayers.get(ws);
+        if (player) {
+            console.log('Client disconnected', { name: player.name, id: player.id });
+        } else {
+            console.log('Client disconnected');
+        }
         multiplayerPlayers.delete(ws);
-        console.log('Client disconnected');
     });
 });
 


### PR DESCRIPTION
## Summary
- send both saved token and Telegram data when joining multiplayer
- log server errors on the client and remove invalid tokens
- add detailed logs in the backend for join process and Telegram auth

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68615bc7c3f883209e0e95633a7738b5